### PR TITLE
DOC: Update example modline for vim and emacs

### DIFF
--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -1,5 +1,5 @@
-.. -*- mode: rst; fill-column: 78; indent-tabs-mode: nil -*-
-.. vi: set ft=rst sts=4 ts=4 sw=4 et tw=79:
+.. -*- mode: rst; fill-column: 76; indent-tabs-mode: nil -*-
+.. vi: set ft=rst sts=4 ts=4 sw=4 et tw=76:
   ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ###
   #
   #   See COPYING file distributed along with the repronim package for the

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -1,5 +1,5 @@
-.. -*- mode: rst; fill-column: 76; indent-tabs-mode: nil -*-
-.. vi: set ft=rst sts=4 ts=4 sw=4 et tw=76:
+.. -*- mode: rst; fill-column: 79; indent-tabs-mode: nil -*-
+.. vi: set ft=rst sts=4 ts=4 sw=4 et tw=79:
   ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ###
   #
   #   See COPYING file distributed along with the repronim package for the


### PR DESCRIPTION
With some testing, setting the modline to 76 allows essentially the same behavior across vim, emacs and pyCharm (when the code width in pyCharm is set to 79 characters).  Why the difference of 3 characters? I believe that:

1. PyCharm adds spaces at the end of every line in the paragraph
1. PyCharm cuts off *before* 79 characters instead of *at* 79 characters
1. PyCharm starts counting at 1 instead of 0

Fun, eh?