### PR TITLE
Doc building fixes

### DIFF
--- a/docs/source/cmdline.rst
+++ b/docs/source/cmdline.rst
@@ -13,7 +13,7 @@ Main command
 .. toctree::
    :maxdepth: 1
 
-   generated/man/repronim
+..   generated/man/repronim
 
 Environments operations
 =======================
@@ -21,7 +21,7 @@ Environments operations
 .. toctree::
    :maxdepth: 1
 
-   generated/man/repronim-ls
+..   generated/man/repronim-ls
    generated/man/repronim-create
    generated/man/repronim-install
 
@@ -31,4 +31,4 @@ Miscellaneous commands
 .. toctree::
    :maxdepth: 1
 
-   generated/man/repronim-test
+..   generated/man/repronim-test

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,7 @@ nose-timer
 # necessary for accessing SecretStorage keyring (system wide Gnome keyring)
 # and nice to have under tox for that
 # dbus-python
+
+# -- required for building docs
+sphinx
+sphinx_rtd_theme


### PR DESCRIPTION
To get "make html" in docs/ work:

- Commented out missing references.

- Added sphinx as a requirement for the virtual environment.  Without this, sphinx-build was being run from the system installation and the repronim package couldn't be found.