### PR TITLE
Added AWS SSH key creation

### DIFF
--- a/repronim/client/awsclient.py
+++ b/repronim/client/awsclient.py
@@ -23,33 +23,8 @@ class AwsClient(Client):
             Configuration parameters for the resource.
         """
 
+        # AWS client created for each individual environment. In this case,
+        # the AWS client is needed to provide AWS subscription credentials.
+        self._client = None
+
         super(AwsClient, self).__init__(config)
-
-    def connect(self):
-        """
-        Connect to service and save client instance to _client property.
-        """
-        # Because of how boto3 works, the connection is initialized in the
-        # environment class that uses this client. See the __init__ of the
-        # Ec2Environment class.
-        return
-
-    def list_environments(self):
-        """
-        Query the resource and return a list of container information.
-
-        Returns
-        -------
-        Dictionary of containers located at the resource.
-        """
-        return {}
-
-    def list_images(self):
-        """
-        Query the resource and return a list of image information.
-
-        Returns
-        -------
-        Dictionary of images located at the resource.
-        """
-        return {}

--- a/repronim/client/base.py
+++ b/repronim/client/base.py
@@ -32,44 +32,17 @@ class Client(Resource):
         """
         super(Client, self).__init__(config)
 
-        self._connection = None
-        self.connect()
+        # The _client attribute must be defined in the child class.
+        if not hasattr(self, '_client'):
+            raise RuntimeError("Unable to find the resource client for '{}'".format(config['resource_id']))
 
-    def get_connection(self):
+    def __call__(self, *args, **kwargs):
         """
-        Returns the connection object needed to communicate with the backend service.
-
-        Returns
-        -------
-        Connection object specific to the backend API being implemented.
-        """
-        return self._connection
-
-    @abc.abstractmethod
-    def connect(self):
-        """
-        Connect to service and save client instance to _connection property.
-        """
-        return
-
-    @abc.abstractmethod
-    def list_environments(self):
-        """
-        Query the resource and return a list of container information.
+        Returns the client object needed to communicate with the backend service.
 
         Returns
         -------
-        Dictionary of containers located at the resource.
+        Client object specific to the backend API being implemented.
         """
-        return {}
-
-    @abc.abstractmethod
-    def list_images(self):
-        """
-        Query the resource and return a list of image information.
-
-        Returns
-        -------
-        Dictionary of images located at the resource.
-        """
-        return {}
+        self._lgr.debug("Retrieving client for resource {}".format(self['resource_id']))
+        return self._client

--- a/repronim/client/dockerclient.py
+++ b/repronim/client/dockerclient.py
@@ -28,32 +28,6 @@ class DockerClient(Client):
         if not 'engine_url' in config:
             config['engine_url'] = 'unix:///var/run/docker.sock'
 
+        self._client = docker.DockerClient(config['engine_url'])
+
         super(DockerClient, self).__init__(config)
-
-    def connect(self):
-        """
-        Connect to service and save client instance to _client property.
-        """
-        # If the connection fails, the DockerException will be raised.
-        self._connection = docker.DockerClient(self.get_config('engine_url'))
-        self._lgr.debug("Connected to docker at {}".format(self.get_config('engine_url')))
-
-    def list_environments(self):
-        """
-        Query the resource and return a list of container information.
-
-        Returns
-        -------
-        Dictionary of containers located at the resource.
-        """
-        return {}
-
-    def list_images(self):
-        """
-        Query the resource and return a list of image information.
-
-        Returns
-        -------
-        Dictionary of images located at the resource.
-        """
-        return {}

--- a/repronim/client/singularityclient.py
+++ b/repronim/client/singularityclient.py
@@ -23,30 +23,6 @@ class SingularityClient(Client):
             Configuration parameters for the resource.
         """
 
+        self._client = None
+
         super(SingularityClient, self).__init__(config)
-
-    def connect(self):
-        """
-        Connect to service and save client instance to _client property.
-        """
-        return
-
-    def list_environments(self):
-        """
-        Query the resource and return a list of container information.
-
-        Returns
-        -------
-        Dictionary of containers located at the resource.
-        """
-        return {}
-
-    def list_images(self):
-        """
-        Query the resource and return a list of image information.
-
-        Returns
-        -------
-        Dictionary of images located at the resource.
-        """
-        return {}

--- a/repronim/client/sshclient.py
+++ b/repronim/client/sshclient.py
@@ -12,6 +12,7 @@ from repronim.client.base import Client
 
 
 class SshClient(Client):
+
     def __init__(self, config):
         """
         Class constructor
@@ -22,30 +23,6 @@ class SshClient(Client):
             Configuration parameters for the resource.
         """
 
+        self._client = None
+
         super(SshClient, self).__init__(config)
-
-    def connect(self):
-        """
-        Connect to service and save client instance to _client property.
-        """
-        return
-
-    def list_environments(self):
-        """
-        Query the resource and return a list of container information.
-
-        Returns
-        -------
-        Dictionary of containers located at the resource.
-        """
-        return {}
-
-    def list_images(self):
-        """
-        Query the resource and return a list of image information.
-
-        Returns
-        -------
-        Dictionary of images located at the resource.
-        """
-        return {}

--- a/repronim/client/tests/test_dockerclient.py
+++ b/repronim/client/tests/test_dockerclient.py
@@ -20,27 +20,26 @@ def test_dockerclient_class():
 
     # Test connecting to a mock docker server.
     config = {
+        'resource_id': 'my-docker-client',
         'engine_url': 'tcp://127.0.0.1:2375'
     }
-    env = DockerClient(config)
 
     with patch('docker.DockerClient') as MockClient, \
             swallow_logs(new_level=logging.DEBUG) as log:
 
         MockClient.return_value = 'connection made to docker'
 
-        env.connect()
+        DockerClient(config)
 
         calls = [
             call('tcp://127.0.0.1:2375')
         ]
         MockClient.assert_has_calls(calls, any_order=True)
 
-        assert env.get_connection() == 'connection made to docker'
-        assert_in('Connected to docker at tcp://127.0.0.1:2375', log.lines)
-
     # Test setting the default engine url if not provided.
-    config = {}
-    env = DockerClient(config)
-    assert env.get_config('engine_url') == 'unix:///var/run/docker.sock'
+    config = {
+        'resource_id': 'my-docker-client'
+    }
+    client = DockerClient(config)
+    assert client['engine_url'] == 'unix:///var/run/docker.sock'
 

--- a/repronim/cmdline/main.py
+++ b/repronim/cmdline/main.py
@@ -23,7 +23,7 @@ from importlib import import_module
 import repronim
 
 from repronim.cmdline import helpers
-from repronim.support.exceptions import InsufficientArgumentsError
+from repronim.support.exceptions import InsufficientArgumentsError, MissingConfigFileError
 from ..utils import setup_exceptionhook, chpwd
 from ..dochelpers import exc_str
 
@@ -244,6 +244,23 @@ def main(args=None):
             # if the func reports inappropriate usage, give help output
             lgr.error('%s (%s)' % (exc_str(exc), exc.__class__.__name__))
             cmdlineargs.subparser.print_usage()
+            sys.exit(1)
+        except MissingConfigFileError as exc:
+            # TODO: ConfigManager is not finding files in the default locations.
+            message = """
+    ERROR: Unable to locate the repronim.cfg file.
+
+    You may either specify one using the --config parameter or place one in the
+    one of following locations:
+
+    1. '/etc/repronim/repronim.cfg'
+    2. 'repronim/config' in all directories defined by $XDG_CONFIG_DIRS
+        (by default: /etc/xdg/)
+    3. 'repronim.cfg' in $XDG_CONFIG_HOME (by default: ~/.config/)
+    4. 'repronim.cfg' in the current directory
+"""
+            # print(message)
+            lgr.error('%s (%s)' % (exc_str(exc), exc.__class__.__name__))
             sys.exit(1)
         except Exception as exc:
             lgr.error('%s (%s)' % (exc_str(exc), exc.__class__.__name__))

--- a/repronim/environment/base.py
+++ b/repronim/environment/base.py
@@ -92,9 +92,7 @@ class Environment(Resource):
         -------
         Instance of a Client class
         """
-        resource_client = self.get_config('resource_client')
-        config_path = self.get_config('config_path')
-        return Resource.factory(resource_client, config_path=config_path)
+        return Resource.factory(self['resource_client'], config_path=self['config_path'])
 
     def add_command(self, command, env=None):
         """

--- a/repronim/environment/dockerenvironment.py
+++ b/repronim/environment/dockerenvironment.py
@@ -41,7 +41,7 @@ class DockerEnvironment(Environment):
 
         # Open a client connection to the Docker engine.
         docker_client = self.get_resource_client()
-        self._client = docker_client.get_connection()
+        self._client = docker_client()
 
     def create(self, name, image_id):
         """
@@ -55,11 +55,11 @@ class DockerEnvironment(Environment):
             Identifier of the image to use when creating the environment.
         """
         if name:
-            self.set_config('name', name)
+            self['name'] = name
         if image_id:
-            self.set_config('base_image_id', image_id)
+            self['base_image_id'] = image_id
 
-        dockerfile = self._get_base_image_dockerfile(self.get_config('base_image_id'))
+        dockerfile = self._get_base_image_dockerfile(self['base_image_id'])
         self._build_image(dockerfile)
         self._run_container()
 
@@ -137,7 +137,7 @@ class DockerEnvironment(Environment):
         #    docker.errors.BuildError - If there is an error during the build.
         #    docker.errors.APIError - If the server returns any other error.
         self._image = self._client.images.build(fileobj=f,
-            tag="repronim:{}".format(self.get_config('name')), rm=True)
+            tag="repronim:{}".format(self['name']), rm=True)
 
     def _run_container(self):
         """
@@ -149,8 +149,8 @@ class DockerEnvironment(Environment):
         #    docker.errors.ImageNotFound - If the specified image does not exist.
         #    docker.errors.APIError - If the server returns an error.
         self._container = self._client.containers.run(image=self._image,
-            stdin_open=self.get_config('stdin_open'), detach=True,
-            name=self.get_config('name'))
+            stdin_open=self['stdin_open'], detach=True,
+            name=self['name'])
 
     def remove_container(self):
         """

--- a/repronim/environment/ec2environment.py
+++ b/repronim/environment/ec2environment.py
@@ -169,8 +169,11 @@ class Ec2Environment(Environment):
         Walk the user through creating an SSH key pair that is saved to
         the AWS platform.
         """
+
+        # TODO: Should move this to something usable application-wide.
+        py3 = version_info[0] > 2
+
         def get_user_input(prompt):
-            py3 = version_info[0] > 2
             if py3:
                 response = input(prompt)
             else:
@@ -239,7 +242,10 @@ Please enter a unique name to create a new key-pair or press [enter] to exit.> "
                 KeyName=key_name
             )
             key_file.write(key_pair.key_material)
-        chmod(key_filename, 0400)
+        if py3:
+            chmod(key_filename, 0o400)
+        else:
+            chmod(key_filename, 0400)
         self._lgr.info("Created private key file %s.", key_filename)
 
         # Save the new info to the resource.

--- a/repronim/environment/ec2environment.py
+++ b/repronim/environment/ec2environment.py
@@ -9,12 +9,15 @@
 """Environment sub-class to provide management of an AWS EC2 instance."""
 
 import boto3
-from sys import version_info, exit
-from os import makedirs, chmod, getcwd
-from os.path import expanduser, dirname, exists, isfile
+from sys import exit
+from os import chmod
+from os.path import join
+from appdirs import AppDirs
 
-from repronim.environment.base import Environment
-from repronim.support.sshconnector2 import SSHConnector2
+from ..environment.base import Environment
+from ..support.sshconnector2 import SSHConnector2
+from ..ui import ui
+from ..utils import assure_dir
 
 
 class Ec2Environment(Environment):
@@ -170,25 +173,16 @@ class Ec2Environment(Environment):
         the AWS platform.
         """
 
-        def get_user_input(prompt):
-            py3 = version_info[0] > 2
-            if py3:
-                response = input(prompt)
-            else:
-                response = raw_input(prompt)
-            return response.strip()
-
-        # Prompt for a name of the key-pair on AWS.
         prompt = """
 You did not specify an EC2 SSH key-pair name to use when creating your EC2 environment.
-Please enter a unique name to create a new key-pair or press [enter] to exit.> """
-        key_name = get_user_input(prompt)
+Please enter a unique name to create a new key-pair or press [enter] to exit"""
+        key_name = ui.question(prompt)
 
         # The user wants to exit.
         if not key_name:
             exit(0)
 
-        # Check to see if key_name already exists.
+        # Check to see if key_name already exists. 3 tries allowed.
         for i in range(3):
             key_pairs = self._ec2_resource.key_pairs.filter(KeyNames=[key_name])
             try:
@@ -197,53 +191,25 @@ Please enter a unique name to create a new key-pair or press [enter] to exit.> "
                 # Catch the exception raised when there is no matching key name at AWS.
                 break
             if i == 2:
-                print('That key name exists already, exiting.')
+                ui.message('That key name exists already, exiting.')
                 exit(1)
             else:
-                prompt = 'That key name exists already, try again. > '
-                key_name = get_user_input(prompt)
+                key_name = ui.question('That key name exists already, try again')
 
-        # Prompt for a path to store the SSH private key.
-        default_path = '{}/.ssh/{}.pem'.format(expanduser("~"), key_name)
-        for i in range(3):
-            prompt = 'Please enter the path to save the private key. [{}]> '.format(default_path)
-            key_filename = get_user_input(prompt)
-
-            if not key_filename:
-                key_filename = default_path
-            # Put .pem at end of private key file if not there already.
-            elif not key_filename.endswith('.pem'):
-                key_filename += '.pem'
-
-            if isfile(key_filename):
-                if i == 2:
-                    print('File exists, exiting.')
-                    exit(1)
-                else:
-                    # TODO: Ask user if they want to overwrite the existing file.
-                    print('File exists, try again.')
-            else:
-                break
-
-        # Make sure the directory for the private key file exists.
-        basedir = dirname(key_filename)
-        if not basedir or not basedir.startswith('/'):
-            basedir = getcwd()
-            key_filename = basedir + '/' + key_filename
-        if not exists(basedir):
-            makedirs(basedir)
+        # Create private key file.
+        basedir = join(
+            AppDirs('repronim', 'repronim.org').user_data_dir, 'ec2_keys')
+        assure_dir(basedir)
+        key_filename = join(basedir, key_name + '.pem')
 
         # Generate the key-pair and save to the private key file.
+        key_pair = self._ec2_resource.create_key_pair(KeyName=key_name)
         with open(key_filename, 'w') as key_file:
-            key_pair = self._ec2_resource.create_key_pair(
-                DryRun=False,
-                KeyName=key_name
-            )
             key_file.write(key_pair.key_material)
         chmod(key_filename, 0o400)
-        self._lgr.info("Created private key file %s.", key_filename)
+        self._lgr.info('Created private key file %s', key_filename)
 
         # Save the new info to the resource.
         self['key_name'] = key_name
         self['key_filename'] = key_filename
-        # TODO: Write new config info to the repronim.cfg file.
+        # TODO: Write new config info to the repronim.cfg file or a registry of some sort.

--- a/repronim/environment/ec2environment.py
+++ b/repronim/environment/ec2environment.py
@@ -170,10 +170,8 @@ class Ec2Environment(Environment):
         the AWS platform.
         """
 
-        # TODO: Should move this to something usable application-wide.
-        py3 = version_info[0] > 2
-
         def get_user_input(prompt):
+            py3 = version_info[0] > 2
             if py3:
                 response = input(prompt)
             else:
@@ -242,10 +240,7 @@ Please enter a unique name to create a new key-pair or press [enter] to exit.> "
                 KeyName=key_name
             )
             key_file.write(key_pair.key_material)
-        if py3:
-            chmod(key_filename, 0o400)
-        else:
-            chmod(key_filename, 0400)
+        chmod(key_filename, 0o400)
         self._lgr.info("Created private key file %s.", key_filename)
 
         # Save the new info to the resource.

--- a/repronim/environment/ec2environment.py
+++ b/repronim/environment/ec2environment.py
@@ -42,9 +42,9 @@ class Ec2Environment(Environment):
         aws_client = self.get_resource_client()
         self._ec2_resource = boto3.resource(
             'ec2',
-            aws_access_key_id=aws_client.get_config('aws_access_key_id'),
-            aws_secret_access_key=aws_client.get_config('aws_secret_access_key'),
-            region_name=self.get_config('region_name')
+            aws_access_key_id=aws_client['aws_access_key_id'],
+            aws_secret_access_key=aws_client['aws_secret_access_key'],
+            region_name=self['region_name']
         )
 
     def create(self, name, image_id):
@@ -59,23 +59,23 @@ class Ec2Environment(Environment):
             Identifier of the image to use when creating the environment.
         """
         if name:
-            self.set_config('name', name)
+            self['name'] = name
         if image_id:
-            self.set_config('base_image_id', image_id)
+            self['base_image_id'] = image_id
 
         instances = self._ec2_resource.create_instances(
-            ImageId=self.get_config('base_image_id'),
-            InstanceType=self.get_config('instance_type'),
-            KeyName=self.get_config('key_name'),
+            ImageId=self['base_image_id'],
+            InstanceType=self['instance_type'],
+            KeyName=self['key_name'],
             MinCount=1,
             MaxCount=1,
-            SecurityGroups=[self.get_config('security_group')],
+            SecurityGroups=[self['security_group']],
         )
 
         # Give the instance a tag name.
         self._ec2_resource.create_tags(
             Resources=[instances[0].id],
-            Tags=[{'Key': 'Name', 'Value': self.get_config('name')}]
+            Tags=[{'Key': 'Name', 'Value': self['name']}]
         )
 
         # Save the EC2 Instance object.
@@ -153,7 +153,7 @@ class Ec2Environment(Environment):
         execution.
         """
         host = self._ec2_instance.public_ip_address
-        key_filename = self.get_config('key_filename')
+        key_filename = self['key_filename']
 
         with SSHConnector2(host, key_filename=key_filename) as ssh:
             for command in self._command_buffer:

--- a/repronim/environment/tests/test_dockerenvironment.py
+++ b/repronim/environment/tests/test_dockerenvironment.py
@@ -17,6 +17,7 @@ from ..dockerenvironment import DockerEnvironment
 def test_dockerenvironment_class():
 
     config = {
+        'resource_id': 'my-docker-env',
         'resource_type': 'docker-environment',
         'resource_client': 'remote-docker-engine',
         'config_path': '/path/to/config/file',
@@ -29,8 +30,7 @@ def test_dockerenvironment_class():
         # Test initializing the environment object.
         env = DockerEnvironment(config)
         calls = [
-            call('remote-docker-engine', config_path='/path/to/config/file'),
-            call().get_connection()
+            call('remote-docker-engine', config_path='/path/to/config/file')
         ]
         MockResourceClient.assert_has_calls(calls, any_order=True)
 
@@ -38,8 +38,8 @@ def test_dockerenvironment_class():
         name = 'my-test-environment'
         image_id = 'ubuntu:trusty'
         env.create(name, image_id)
-        assert env.get_config('name') == 'my-test-environment'
-        assert env.get_config('base_image_id') == 'ubuntu:trusty'
+        assert env['name'] == 'my-test-environment'
+        assert env['base_image_id'] == 'ubuntu:trusty'
 
         # Test connecting to an environment and running some install commands.
         env = DockerEnvironment(config)
@@ -50,10 +50,10 @@ def test_dockerenvironment_class():
         env.add_command(command)
         env.execute_command_buffer()
         calls = [
-            call().get_connection().containers.get('my-test-environment'),
-            call().get_connection().containers.get().exec_run(
+            call()().containers.get('my-test-environment'),
+            call()().containers.get().exec_run(
                 cmd=['apt-get', 'install', 'bc'], stream=True),
-            call().get_connection().containers.get().exec_run(
+            call()().containers.get().exec_run(
                 cmd=['apt-get', 'install', 'xeyes'], stream=True),
         ]
         MockResourceClient.assert_has_calls(calls, any_order=True)

--- a/repronim/environment/tests/test_ec2environment.py
+++ b/repronim/environment/tests/test_ec2environment.py
@@ -8,7 +8,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
 import logging
-from mock import patch, call, MagicMock
+from mock import patch, call
 
 from ...utils import swallow_logs
 from ...tests.utils import assert_in
@@ -17,6 +17,7 @@ from ..ec2environment import Ec2Environment
 def test_ec2environment_class():
 
     config = {
+        'resource_id': 'my-ec2-env',
         'resource_type': 'ec2-environment',
         'resource_client': 'my-aws-subscription',
         'region_name': 'us - east - 1',
@@ -35,9 +36,7 @@ def test_ec2environment_class():
         # Test initializing the environment object.
         env = Ec2Environment(config)
         calls = [
-            call('my-aws-subscription', config_path='/path/to/config/file'),
-            call().get_config('aws_access_key_id'),
-            call().get_config('aws_secret_access_key'),
+            call('my-aws-subscription', config_path='/path/to/config/file')
         ]
         MockResourceClient.assert_has_calls(calls, any_order=True)
 
@@ -45,8 +44,8 @@ def test_ec2environment_class():
         name = 'my-test-environment'
         image_id = 'ubuntu:trusty'
         env.create(name, image_id)
-        assert env.get_config('name') == 'my-test-environment'
-        assert env.get_config('base_image_id') == 'ubuntu:trusty'
+        assert env['name'] == 'my-test-environment'
+        assert env['base_image_id'] == 'ubuntu:trusty'
 
         # Test running some install commands.
         command = ['apt-get', 'install', 'bc']

--- a/repronim/environment/tests/test_ec2environment.py
+++ b/repronim/environment/tests/test_ec2environment.py
@@ -13,6 +13,8 @@ from mock import patch, call
 from ...utils import swallow_logs
 from ...tests.utils import assert_in
 from ..ec2environment import Ec2Environment
+from ...tests.utils import with_testsui
+
 
 def test_ec2environment_class():
 
@@ -20,7 +22,7 @@ def test_ec2environment_class():
         'resource_id': 'my-ec2-env',
         'resource_type': 'ec2-environment',
         'resource_client': 'my-aws-subscription',
-        'region_name': 'us - east - 1',
+        'region_name': 'us-east-1',
         'instance_type': 't2.micro',
         'security_group': 'SSH only',
         'key_name': 'aws-key-name',
@@ -60,3 +62,27 @@ def test_ec2environment_class():
         MockSSH.assert_has_calls(calls, any_order=True)
         assert_in("Running command '['apt-get', 'install', 'bc']'", log.lines)
         assert_in("Running command '['apt-get', 'install', 'xeyes']'", log.lines)
+
+# @with_testsui(responses='my-new-key-pair')
+# def test_ec2environment_create_key_pair():
+#
+#     config = {
+#         'resource_id': 'my-ec2-env',
+#         'resource_type': 'ec2-environment',
+#         'resource_client': 'my-aws-subscription',
+#         'region_name': 'us-east-1',
+#         'instance_type': 't2.micro',
+#         'security_group': 'SSH only',
+#         'config_path': '/path/to/config/file',
+#     }
+#
+#     with patch('boto3.resource') as MockEc2Client, \
+#         patch('repronim.resource.Resource.factory') as MockResourceClient, \
+#             swallow_logs(new_level=logging.DEBUG) as log:
+#
+#         # Test initializing the environment object.
+#         env = Ec2Environment(config)
+#
+#         env.create_key_pair()
+#
+#         assert 1 == 1

--- a/repronim/environment/tests/test_localshellenvironment.py
+++ b/repronim/environment/tests/test_localshellenvironment.py
@@ -18,7 +18,9 @@ from ...cmd import Runner
 
 def test_localshellenvironment_class():
 
-    config = {}
+    config = {
+        'resource_id': 'my-localshell-env'
+    }
 
     with patch.object(Runner, 'run', return_value='installed package') as MockRunner, \
             swallow_logs(new_level=logging.DEBUG) as log:

--- a/repronim/interface/base.py
+++ b/repronim/interface/base.py
@@ -17,6 +17,7 @@ import re
 import textwrap
 
 from ..ui import ui
+from ..resource import Resource
 
 
 def get_api_name(intfspec):
@@ -286,3 +287,29 @@ class Interface(object):
         except KeyboardInterrupt:
             ui.error("\nInterrupted by user while doing magic")
             sys.exit(1)
+
+    @staticmethod
+    def validate_resource(resource_id, config, type=None):
+        """
+        Validate the resource given. Throws and exception if validation fails.
+
+        Parameters
+        ----------
+        resource_id : string
+            ID of resource in the repronim.cfg file.
+        config : dictionary
+            Dictionary of config parameters for the resource.
+        type : string
+            If set, checks to see if the resource is of type 'environment' or
+            'client'
+        """
+        resources = Resource.get_resource_list(config_path=config)
+        try:
+            resource = resources[resource_id]
+        except KeyError:
+            raise RuntimeError(
+                "Unable to find resource '{}' in the config file.".format(resource_id))
+
+        if type and not resource['resource_type'].endswith(type):
+            raise RuntimeError(
+                "'{}' is not a resource of type {}.".format(resource_id, type))

--- a/repronim/interface/create.py
+++ b/repronim/interface/create.py
@@ -142,9 +142,10 @@ class Create(Interface):
             name = generate_environment_name()
         else:
             resource_client = env_resource.get_resource_client()
-            if name in resource_client.list_environments():
-                raise ValueError(
-                    "{} environment is already known to the resource.", name)
+            # TODO: Get a listing of environments.
+            # if name in resource_client.list_environments():
+            #     raise ValueError(
+            #         "{} environment is already known to the resource.", name)
 
         env_resource.create(name, image)
 

--- a/repronim/interface/create.py
+++ b/repronim/interface/create.py
@@ -123,15 +123,14 @@ class Create(Interface):
         print("SPEC: {}".format(specs[0]))
 
         # Load, while possible merging/augmenting sequentially
-        lgr.info("Loading the specs %s", specs)
+        # lgr.info("Loading the specs %s", specs)
         provenance = Provenance.factory(specs[0])
         lgr.debug("SPEC: {}".format(specs))
 
         if not resource:
             raise InsufficientArgumentsError("Need a --resource")
+        Interface.validate_resource(resource, config, 'environment')
         print("RESOURCE: {}".format(resource))
-
-        # TODO: Check to make sure resource_type is "environment"
 
         if only_env:
             raise NotImplementedError

--- a/repronim/interface/install.py
+++ b/repronim/interface/install.py
@@ -73,9 +73,8 @@ class Install(Interface):
 
         if not resource:
             raise InsufficientArgumentsError("Need at least a single --resource")
+        Interface.validate_resource(resource, config, 'environment')
         print("RESOURCE: {}".format(resource))
-
-        # TODO: Check to make sure resource_type is "environment"
 
         if not name:
             raise InsufficientArgumentsError("Need at least a single --name")

--- a/repronim/interface/ls.py
+++ b/repronim/interface/ls.py
@@ -54,9 +54,11 @@ class Ls(Interface):
     def __call__(names, config, verbose=False):
 
         resources = Resource.get_resource_list(config_path=config)
-        print('{:<30} {:<20}'.format('RESOURCE', 'TYPE'))
+
+        print('\n{:<30} {:<20}'.format('RESOURCE', 'TYPE'))
         print('{:<30} {:<20}'.format('--------', '----'))
         for key in resources:
             lgr.debug('listing resource {}'.format(key))
             print('{:<30} {:<20}'.format(resources[key]['resource_id'],
                                            resources[key]['resource_type']))
+        print('\n')

--- a/repronim/resource.py
+++ b/repronim/resource.py
@@ -33,7 +33,22 @@ class Resource(object):
             Configuration parameters for the resource.
         """
         self._config = config
+        if not 'resource_id' in self._config:
+            raise MissingConfigError("Missing 'resource_id' config parameter")
+
         self._lgr = logging.getLogger('repronim.resource')
+
+    def __repr__(self):
+        return 'Resource({})'.format(self._config['resource_id'])
+
+    def __len__(self):
+        return len(self._config)
+
+    def __getitem__(self, item):
+        return self._config[item]
+
+    def __setitem__(self, key, value):
+        self._config[key] = value
 
     @staticmethod
     def factory(resource_id, config = {}, config_path=None):
@@ -127,39 +142,3 @@ class Resource(object):
                 resources[resource_id] = cm._sections[name]
                 resources[resource_id]['resource_id'] = resource_id
         return resources
-
-    def get_config(self, key):
-        """
-        Returns a configuration parameter indexed by the key.
-
-        Parameters
-        ----------
-        key : string
-            Identifier of configuration setting.
-
-        Returns
-        -------
-        Value of configuration parameter indexed by the key.
-        """
-        if key in self._config:
-            return self._config[key]
-
-        raise MissingConfigError("Missing configuration parameter: '%s'" % key)
-
-    def set_config(self, key, value):
-        """
-        Set a configuration parameter for the instance of the resource.
-
-        Parameters
-        ----------
-        key : string
-            Identifier of configuration setting.
-
-        value : string
-            Value of configuration setting.
-
-        Returns
-        -------
-
-        """
-        self._config[key] = value

--- a/repronim/resource.py
+++ b/repronim/resource.py
@@ -50,6 +50,9 @@ class Resource(object):
     def __setitem__(self, key, value):
         self._config[key] = value
 
+    def __contains__(self, item):
+        return item in self._config
+
     @staticmethod
     def factory(resource_id, config = {}, config_path=None):
         """

--- a/repronim/resource.py
+++ b/repronim/resource.py
@@ -13,7 +13,7 @@ import abc
 import logging
 
 from .config import ConfigManager
-from .support.exceptions import MissingConfigError
+from .support.exceptions import MissingConfigError, MissingConfigFileError
 
 
 class Resource(object):
@@ -114,7 +114,7 @@ class Resource(object):
         else:
             cm = ConfigManager()
         if len(cm._sections) == 1:
-            raise MissingConfigError("Cannot locate a repronim.cfg file.")
+            raise MissingConfigFileError("Unable to locate a repronim.cfg file.")
 
         return cm
 

--- a/repronim/support/exceptions.py
+++ b/repronim/support/exceptions.py
@@ -47,5 +47,10 @@ class SpecLoadingError(IOError):
 
 
 class MissingConfigError(RuntimeError):
-    """To be raised when missing configuration files or parameters"""
+    """To be raised when missing configuration a parameter"""
+    pass
+
+
+class MissingConfigFileError(RuntimeError):
+    """To be raised when missing the configuration file"""
     pass

--- a/repronim/tests/files/repronim.cfg
+++ b/repronim/tests/files/repronim.cfg
@@ -1,11 +1,75 @@
-# Define a resources, here are the allowed resource types:
+# To define a resource, here are the allowed resource types with their possible
+# configuration options:
+#
+# Client resources provide the information necessary to connect to backend
+# platforms such as an AWS subscription or remote docker engine.
+#
 #   aws-client
+#   ----------
+#       aws_access_key_id:  AWS credential needed to access the AWS APIs. Access
+#           key ID example: AKIAIOSFODNN7EXAMPLE
+#
+#       aws_secret_access_key:  Second part of the AWS credential needed to access
+#           the AWS APIs. Secret access key example: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+#
 #   docker-client
-#   singularity-client (in development)
-#   ssh-client (in development)
-#   docker-environmnet
+#   -------------
+#       engine_url (optional):  IP and port of the server where the docker engine is
+#           running. (e.g. tcp://92.5.23.75:2375) If this option is not defined,
+#           its value will default to the localhost at 'unix:///var/run/docker.sock'
+#
+# Environment resources provide the information needed to create and/or connect
+# to a computational environment such as an AWS EC2 instance or Docker container.
+#
+# All environments have the following optional parameters:
+#
+#   config_path (optional):  Path to repronim configuration file. If none
+#       is specified, the following files will be checked for existence
+#       in this order:
+#           1. '/etc/repronim/repronim.cfg'
+#           2. 'repronim/config' in all directories defined by $XDG_CONFIG_DIRS
+#               by default: /etc/xdg/)
+#           3. 'repronim.cfg' in $XDG_CONFIG_HOME (by default: ~/.config/)
+#           4. 'repronim.cfg' in the current directory
+#
+#   name (optional):  User-friendly name for the environment. This name
+#       will be referenced when connecting to or listing an environment. A
+#       name will be randomly generated if none is supplied.
+#
+# The following are the environment resource types:
+#
+#   docker-environment
+#   ------------------
+#       resource_client:  Repronim resource ID for a client resource. Needed
+#           to determine where the Docker engine is located.
+#
+#       base_image_id (optional):  Docker image identifier to be used when
+#           creating the container. Defaults to: 'ubuntu:latest'
+#
 #   ec2-environment
-#   local-environment (in development)
+#   ---------------
+#       resource_client:  Repronim resource ID for a client resource. Needed
+#           to determine the credentials required to connect to the AWS APIs.
+#
+#       region_name:  Region where EC2 instance is located. (e.g. us-east-1)
+#
+#       key_name:  Name of SSH key pair registered in the AWS subscription.
+#           See: http://http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
+#
+#       key_filename:  Path to the SSH private key needed to connect to the
+#           EC2 instance.
+#
+#       base_image_id (optional):  ID for the Amazon AMI to use when creating
+#           the EC2 instance. Defaults to 'ami-c8580bdf' which is Ubuntu 14.04 LTS
+#
+#       instance_type (optional):  AWS compute resource type. Defaults to 't2.micro'
+#
+#       security_group (optional):  AWS security group (firewall) to use for the EC2
+#           instance. Defaults to 'default' security group.
+#
+#   local-environment
+#   -----------------
+#       (No localhost specific config parameters defined yet.)
 
 [resource remote-docker]
 resource_type = docker-client

--- a/repronim/tests/test_resource.py
+++ b/repronim/tests/test_resource.py
@@ -22,11 +22,11 @@ def test_resource_class(repronim_cfg_path):
 
     # Test reading a repronim.cfg file.
     resource = Resource.factory('ec2-workflow', config_path=repronim_cfg_path)
-    assert resource.get_config('resource_id') == 'ec2-workflow'
-    assert resource.get_config('resource_type') == 'ec2-environment'
-    assert resource.get_config('resource_client') == 'my-aws-subscription'
-    assert resource.get_config('region_name') == 'us-east-1'
-    assert resource.get_config('instance_type') == 't2.micro'
+    assert resource['resource_id'] == 'ec2-workflow'
+    assert resource['resource_type'] == 'ec2-environment'
+    assert resource['resource_client'] == 'my-aws-subscription'
+    assert resource['region_name'] == 'us-east-1'
+    assert resource['instance_type'] == 't2.micro'
 
     # Test overriding the settings read from a repronim.cfg file.
     config = {
@@ -34,25 +34,25 @@ def test_resource_class(repronim_cfg_path):
         'instance_type': 'm3.medium'
     }
     resource = Resource.factory('ec2-workflow', config, config_path=repronim_cfg_path)
-    assert len(resource._config) == 11
-    assert resource.get_config('resource_id') == 'ec2-workflow'
-    assert resource.get_config('resource_type') == 'ec2-environment'
-    assert resource.get_config('resource_client') == 'my-aws-subscription'
-    assert resource.get_config('region_name') == 'us-east-1'
-    assert resource.get_config('instance_type') == 'm3.medium'
-    assert resource.get_config('new_config_var') == 'abc123'
+    assert len(resource) == 11
+    assert resource['resource_id'] == 'ec2-workflow'
+    assert resource['resource_type'] == 'ec2-environment'
+    assert resource['resource_client'] == 'my-aws-subscription'
+    assert resource['region_name'] == 'us-east-1'
+    assert resource['instance_type'] == 'm3.medium'
+    assert resource['new_config_var'] == 'abc123'
 
     # Test updating a configuration setting.
-    assert resource.get_config('instance_type') == 'm3.medium'
-    resource.set_config('instance_type', 't2.large')
-    assert resource.get_config('instance_type') == 't2.large'
+    assert resource['instance_type'] == 'm3.medium'
+    resource['instance_type'] = 't2.large'
+    assert resource['instance_type'] == 't2.large'
 
     # TODO: Test below is not working in python 3.
     # Python 3 complains that MissingConfigError object has no attribute 'message'
     #
     # Test raising an exception if a config setting is missing.
     # try:
-    #     resource.get_config('i-do-not-exist')
+    #     resource['i-do-not-exist']
     # except MissingConfigError as e:
     #     assert e.message == "Missing configuration parameter: 'i-do-not-exist'"
     #


### PR DESCRIPTION
This pull request includes:

1. Adding code to prompt the user for information if they don't have a key_name declared in their ec2-environment configuration.
2. Documenting the options in repronim.cfg at the top of the file in tests/files/repronim.cfg
3. After reading the first chapter of "Fluent Python", made chages to the Resource class to make it more Pythonic.
4. Enhanced error handling and user notices for command line options.

The unit testing of the new Ec2Environment.create_key_pair() method is beyond me at this point as it contains user prompts. Will work on that and bring it up at Monday's meeting to see if you have any thoughts on how to handle it.

My next step is to work on enhancing "repronim ls" and on allowing users to log directly into their environments through the repronim command line.

Enjoy the new code!
