### PR TITLE
ENH: EC2 key creation logic improvements

### DIFF
--- a/repronim/environment/ec2environment.py
+++ b/repronim/environment/ec2environment.py
@@ -9,7 +9,6 @@
 """Environment sub-class to provide management of an AWS EC2 instance."""
 
 import boto3
-from sys import exit
 from os import chmod
 from os.path import join
 from appdirs import AppDirs
@@ -178,12 +177,12 @@ You did not specify an EC2 SSH key-pair name to use when creating your EC2 envir
 Please enter a unique name to create a new key-pair or press [enter] to exit"""
         key_name = ui.question(prompt)
 
-        # The user wants to exit.
-        if not key_name:
-            exit(0)
-
         # Check to see if key_name already exists. 3 tries allowed.
         for i in range(3):
+            # The user wants to exit.
+            if not key_name:
+                raise SystemExit("Empty keyname was provided, exiting")
+
             key_pairs = self._ec2_resource.key_pairs.filter(KeyNames=[key_name])
             try:
                 len(list(key_pairs))
@@ -191,8 +190,7 @@ Please enter a unique name to create a new key-pair or press [enter] to exit"""
                 # Catch the exception raised when there is no matching key name at AWS.
                 break
             if i == 2:
-                ui.message('That key name exists already, exiting.')
-                exit(1)
+                raise SystemExit('That key name exists already, exiting.')
             else:
                 key_name = ui.question('That key name exists already, try again')
 

--- a/repronim/environment/ec2environment.py
+++ b/repronim/environment/ec2environment.py
@@ -91,21 +91,24 @@ class Ec2Environment(Environment):
         # Save the EC2 Instance object.
         self._ec2_instance = self._ec2_resource.Instance(instances[0].id)
 
-        self._lgr.info("Waiting for EC2 instance %s to start running...", self._ec2_instance.id)
+        instance_id = self._ec2_instance.id
+        self._lgr.info("Waiting for EC2 instance %s to start running...",
+                       instance_id)
         self._ec2_instance.wait_until_running(
             Filters=[
                 {
                     'Name': 'instance-id',
-                    'Values': [self._ec2_instance.id]
+                    'Values': [instance_id]
                 },
             ]
         )
-        self._lgr.info("EC2 instance %s to start running!", self._ec2_instance.id)
+        self._lgr.info("EC2 instance %s to start running!", instance_id)
 
-        self._lgr.info("Waiting for EC2 instance %s to complete initialization...", self._ec2_instance.id)
+        self._lgr.info("Waiting for EC2 instance %s to complete initialization...",
+                       instance_id)
         waiter = self._ec2_instance.meta.client.get_waiter('instance_status_ok')
-        waiter.wait(InstanceIds=[self._ec2_instance.id])
-        self._lgr.info("EC2 instance %s initialized!")
+        waiter.wait(InstanceIds=[instance_id])
+        self._lgr.info("EC2 instance %s initialized!", instance_id)
 
     def connect(self, name):
         """

--- a/repronim/environment/ec2environment.py
+++ b/repronim/environment/ec2environment.py
@@ -20,8 +20,6 @@ from ..ui import ui
 from ..utils import assure_dir
 from ..dochelpers import exc_str
 
-import logging
-lgr = logging.getLogger('repronim.environment.ec2')
 
 class Ec2Environment(Environment):
 
@@ -202,7 +200,7 @@ Please enter a unique name to create a new key-pair or press [enter] to exit"""
                     # We have no clue what it is
                     raise
             except Exception as exc:
-                lgr.error(
+                self._lgr.error(
                     "Caught some unknown exception while checking key %s: %s",
                     key_pair,
                     exc_str(exc)

--- a/repronim/resource.py
+++ b/repronim/resource.py
@@ -33,7 +33,7 @@ class Resource(object):
             Configuration parameters for the resource.
         """
         self._config = config
-        if not 'resource_id' in self._config:
+        if 'resource_id' not in self._config:
             raise MissingConfigError("Missing 'resource_id' config parameter")
 
         self._lgr = logging.getLogger('repronim.resource')

--- a/repronim/tests/files/demo_spec1.yml
+++ b/repronim/tests/files/demo_spec1.yml
@@ -84,6 +84,12 @@ packages:
    TODOMORE: TODO
    component: contrib
    architecture: amd64
+   # --- User knowledge which we might not be able to "trace" but should allow for 
+   # custom specification, e.g. environment variables which might guide the
+   # package installation procedure/initial configuration
+   # 
+   # environment:
+   #  - VAR1: xxxx
 
  - name: python-nibabel
    distributions:


### PR DESCRIPTION
- avoid using `exit()` call directly.  Ideally we should come up with some dedicated exception for this situation
- check for empty key at any iteration

I still feel that we should allow to reuse existing key, but since function is `create_key_pair` I left that alone for now ;)

This one should finally Closes #42  ;-)